### PR TITLE
[feature/immutable-list] Convert list to immutable list when using compose

### DIFF
--- a/app/src/main/java/com/nanamare/movie/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/com/nanamare/movie/ui/MainActivityViewModel.kt
@@ -18,6 +18,8 @@ import com.nanamare.movie.ui.paging.inmemory.SearchMoviePagingSource
 import com.nanamare.movie.ui.paging.inmemory.UpcomingMoviePagingSource
 import com.nanamare.movie.ui.screen.Mode
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
@@ -46,7 +48,7 @@ interface MainActivityViewModel : NavigationViewModel {
     val upcomingMovie: Flow<PagingData<Movie>>
     val trendingMovie: Flow<PagingData<Movie>>
     val searchMovie: StateFlow<PagingData<Movie>>
-    val genreListUiState: StateFlow<UiState<List<GenreModel>>>
+    val genreListUiState: StateFlow<UiState<ImmutableList<GenreModel>>>
     val isRefresh: StateFlow<Boolean>
     val keyboardTrigger: SharedFlow<Long>
     val error: SharedFlow<Unit>
@@ -131,7 +133,7 @@ class MainActivityViewModelImpl @Inject constructor(
             )
 
     override val genreListUiState = flow {
-        emit(getGenreListUseCase().toUiState())
+        emit(getGenreListUseCase().mapCatching { it.toImmutableList() }.toUiState())
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(STOP_TIME_OUT_MILLS),

--- a/app/src/main/java/com/nanamare/movie/ui/screen/GenreScreen.kt
+++ b/app/src/main/java/com/nanamare/movie/ui/screen/GenreScreen.kt
@@ -31,6 +31,7 @@ import com.nanamare.movie.R
 import com.nanamare.movie.ui.MainActivityViewModel
 import com.nanamare.movie.ui.base.NavigationViewModel
 import com.nanamare.movie.ui.base.getActivityViewModel
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun GenreScreen(
@@ -64,7 +65,7 @@ fun GenreScreen(
 @Composable
 fun GenreList(
     modifier: Modifier,
-    genreList: List<GenreModel>,
+    genreList: ImmutableList<GenreModel>,
     block: (NavigationViewModel.Screen) -> Unit
 ) {
     LazyColumn(modifier.padding(horizontal = 12.dp)) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidxActivityCompose = "1.7.2"
 okhttp = "4.11.0"
 retrofit = "2.9.0"
 kotlinxSerializationJson = "1.5.1"
+kotlinxCollectionsImmutable = "0.3.5"
 retrofitKotlinxSerializationJson = "1.0.0"
 kotlin = "1.8.10"
 androidGradlePlugin = "7.3.1"
@@ -52,6 +53,7 @@ flipper = "0.190.0"
 retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 okhttp-core = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -178,7 +178,8 @@ compose = ["androidx-compose-activity",
     "androidx-constraintlayout-compose",
     "androidx-paging-compose",
     "androidx-lifecycle-viewmodel",
-    "androidx-navigation-compose"
+    "androidx-navigation-compose",
+    "kotlinx-immutable"
 ]
 debugging = ["flipper",
     "flipper-network-plugin",


### PR DESCRIPTION
- When using Jetpack Compose, list type is not stable so it can cause recomposition when ui state renewed
- It can be escaped to use stable(or immutable) annotation in genreuimodel wrapping list data or use kotlinx.collections.immutable collection
    - In this case, there are no specific ui model for custom domain, so I just use kotlinx.immutable.collection

### Reference

- [Jetpack Compose Stability](https://medium.com/androiddevelopers/jetpack-compose-stability-explained-79c10db270c8)